### PR TITLE
GH1 compile with openjdk11

### DIFF
--- a/esealing-client/pom.xml
+++ b/esealing-client/pom.xml
@@ -8,7 +8,8 @@
 	<version>0.0.1-SNAPSHOT</version>
 
 	<properties>
-		<java.version>1.8</java.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
@@ -83,5 +84,26 @@
 			<version>4.10</version>
 		</dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                  <dependency>
+		       <groupId>jakarta.xml.bind</groupId>
+                       <artifactId>jakarta.xml.bind-api</artifactId>
+                       <version>2.3.3</version>
+	          </dependency>
+	       	  <dependency>
+        	       <groupId>com.sun.xml.bind</groupId>
+                       <artifactId>jaxb-impl</artifactId>
+                       <version>2.3.3</version>
+                  </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>
 

--- a/esealing-ws/pom.xml
+++ b/esealing-ws/pom.xml
@@ -58,13 +58,33 @@
           <version>7.1</version>
         </dependency>
 
-	<!-- IAIK sunpkcs11-wrapper, to access an HSM -->
-	<dependency>
-		<groupId>org.xipki.iaik</groupId>
-		<artifactId>sunpkcs11-wrapper</artifactId>
-		<version>1.4.7</version>
-	</dependency>
+        <!-- IAIK sunpkcs11-wrapper, to access an HSM -->
+        <dependency>
+                <groupId>org.xipki.iaik</groupId>
+                <artifactId>sunpkcs11-wrapper</artifactId>
+                <version>1.4.7</version>
+        </dependency>
+</dependencies>
 
-    </dependencies>
+    <profiles>
+        <profile>
+            <id>jdk11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                  <dependency>
+		       <groupId>jakarta.xml.bind</groupId>
+                       <artifactId>jakarta.xml.bind-api</artifactId>
+                       <version>2.3.3</version>
+	          </dependency>
+	       	  <dependency>
+        	       <groupId>com.sun.xml.bind</groupId>
+                       <artifactId>jaxb-impl</artifactId>
+                       <version>2.3.3</version>
+                  </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,8 @@
     </modules>
 
     <properties>
-        <java.version>1.8</java.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <springfox.version>2.9.2</springfox.version>
         <httpclient.version>4.5.11</httpclient.version>
     </properties>
@@ -48,5 +49,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
 </project>


### PR DESCRIPTION
Fix for #1 

- added jaxb and jaxb-impl as dependencies in a new profile
- changed java.version property into maven.source.version and maven.target.version

Signed-off-by: Bart Hanssens <bart.hanssens@bosa.fgov.be>